### PR TITLE
upgrade dlib to 19.18

### DIFF
--- a/dlib-19.18.tar.bz2.md5sum
+++ b/dlib-19.18.tar.bz2.md5sum
@@ -1,0 +1,1 @@
+b605c7e5d484346093d9de5a7ff0117f  dlib-19.18.tar.bz2


### PR DESCRIPTION
downloaded from http://dlib.net/
currently testing https://github.com/ipa320/cob_extern/pull/104